### PR TITLE
Fix exception due to missing config option

### DIFF
--- a/epubpaginator.py
+++ b/epubpaginator.py
@@ -236,6 +236,7 @@ def main():
             config["epubcheck"] = args.epubcheck
             config["chk_orig"] = args.chk_orig
             config["chk_paged"] = args.chk_paged
+            config["quiet"] = args.quiet
             config["DEBUG"] = args.DEBUG
             return dict(config)
 


### PR DESCRIPTION
After a clone, running
    `python3 epubpaginator.py FarmBoy.epub`
results in an exception:
`Traceback (most recent call last):
  File "...devl/python/epub_pager/epubpaginator.py", line 350, in <module>
    main()
  File ".../devl/python/epub_pager/epubpaginator.py", line 266, in main
    paginator.quiet = config["quiet"]
                      ~~~~~~^^^^^^^^^`
The option is there, just needed to add in `get_config()` to `args`  when no user config present. 


